### PR TITLE
Add newline before namespace tag

### DIFF
--- a/Sources/XCResource/XCSnippet/File/XCSnippetFileSummaryTagger.swift
+++ b/Sources/XCResource/XCSnippet/File/XCSnippetFileSummaryTagger.swift
@@ -23,8 +23,8 @@ class XCSnippetFileSummaryTagger {
 
     func tag(_ content: String, tag: String) -> String {
         var result = clearTags(content)
-        if !result.isEmpty && !result.hasSuffix("\n") {
-            result += "\n"
+        if !result.isEmpty && !result.hasSuffix("\n\n") {
+            result += result.hasSuffix("\n") ? "\n" : "\n\n"
         }
         result += "\(marker)\(tag)"
         return result

--- a/Tests/XCResourceTests/XCSnippetFileSummaryTaggerTests.swift
+++ b/Tests/XCResourceTests/XCSnippetFileSummaryTaggerTests.swift
@@ -24,25 +24,37 @@ final class XCSnippetFileSummaryTaggerTests: XCTestCase {
                 initialContent: "CONTENT",
                 initialTag: nil,
                 tag: "A",
-                expectedContent: "CONTENT\nNamespace: A"
+                expectedContent: "CONTENT\n\nNamespace: A"
             ),
             TagContentSample(
                 initialContent: "CONTENT Namespace: A",
                 initialTag: "A",
                 tag: "B",
-                expectedContent: "CONTENT\nNamespace: B"
+                expectedContent: "CONTENT\n\nNamespace: B"
             ),
             TagContentSample(
                 initialContent: "Namespace: A CONTENT\nNamespace: B\nNamespace: C",
                 initialTag: "A",
                 tag: "B",
-                expectedContent: "CONTENT\nNamespace: B"
+                expectedContent: "CONTENT\n\nNamespace: B"
             ),
             TagContentSample(
                 initialContent: "Namespace: A CONTENT\nNamespace: B\nNamespace: C END",
                 initialTag: "A",
                 tag: "B",
-                expectedContent: "CONTENT\nEND\nNamespace: B"
+                expectedContent: "CONTENT\nEND\n\nNamespace: B"
+            ),
+            TagContentSample(
+                initialContent: "CONTENT\n",
+                initialTag: nil,
+                tag: "B",
+                expectedContent: "CONTENT\n\nNamespace: B"
+            ),
+            TagContentSample(
+                initialContent: "CONTENT\n\n",
+                initialTag: nil,
+                tag: "B",
+                expectedContent: "CONTENT\n\nNamespace: B"
             ),
         ]
         samples.enumerated().forEach { i, sample in


### PR DESCRIPTION
- Updated namespace format: two new lines now precedes the `Namespace:` indicator.